### PR TITLE
Add Stripe payment intent integration and secure API config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+STRIPE_SECRET_KEY=sk_test_your_secret_key
+STRIPE_PUBLISHABLE_KEY=pk_test_your_publishable_key

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "type": "commonjs",
   "dependencies": {
     "express": "^4.18.2",
-    "stripe": "^14.0.0"
+    "stripe": "^14.0.0",
+    "dotenv": "^16.3.1"
   }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -2,21 +2,44 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <title>Stripe Sample</title>
+  <title>Stripe Payment Intent Demo</title>
 </head>
 <body>
-  <h1>Stripe Checkout Demo</h1>
-  <button id="checkout">Checkout</button>
+  <h1>Stripe Payment Intent Demo</h1>
+  <div id="card-element"></div>
+  <button id="pay-button">Pay</button>
+  <div id="payment-result"></div>
   <script src="https://js.stripe.com/v3/"></script>
   <script>
-    const stripe = Stripe('pk_test_replace_with_your_public_key');
-    const button = document.getElementById('checkout');
-    button.addEventListener('click', async () => {
-      const response = await fetch('/create-checkout-session', { method: 'POST' });
-      const session = await response.json();
-      const result = await stripe.redirectToCheckout({ sessionId: session.id });
-      if (result.error) {
-        alert(result.error.message);
+    let stripe, card, clientSecret;
+
+    fetch('/config')
+      .then((res) => res.json())
+      .then(({ publishableKey }) => {
+        stripe = Stripe(publishableKey);
+        const elements = stripe.elements();
+        card = elements.create('card');
+        card.mount('#card-element');
+      });
+
+    fetch('/create-payment-intent', { method: 'POST' })
+      .then((res) => res.json())
+      .then((data) => {
+        clientSecret = data.clientSecret;
+      });
+
+    document.getElementById('pay-button').addEventListener('click', async () => {
+      const resultElement = document.getElementById('payment-result');
+      const { error } = await stripe.confirmCardPayment(clientSecret, {
+        payment_method: {
+          card: card,
+        },
+      });
+
+      if (error) {
+        resultElement.textContent = error.message;
+      } else {
+        resultElement.textContent = 'Payment succeeded!';
       }
     });
   </script>

--- a/server.js
+++ b/server.js
@@ -1,3 +1,5 @@
+require('dotenv').config();
+
 const express = require('express');
 const stripe = require('stripe')(process.env.STRIPE_SECRET_KEY);
 
@@ -5,27 +7,18 @@ const app = express();
 app.use(express.static('public'));
 app.use(express.json());
 
-app.post('/create-checkout-session', async (req, res) => {
+app.get('/config', (req, res) => {
+  res.json({ publishableKey: process.env.STRIPE_PUBLISHABLE_KEY });
+});
+
+app.post('/create-payment-intent', async (req, res) => {
   try {
-    const session = await stripe.checkout.sessions.create({
-      payment_method_types: ['card'],
-      mode: 'payment',
-      line_items: [
-        {
-          price_data: {
-            currency: 'usd',
-            product_data: {
-              name: 'Sample Product',
-            },
-            unit_amount: 1000,
-          },
-          quantity: 1,
-        },
-      ],
-      success_url: `${req.headers.origin}/success.html`,
-      cancel_url: `${req.headers.origin}/cancel.html`,
+    const paymentIntent = await stripe.paymentIntents.create({
+      currency: 'usd',
+      amount: 1000,
+      automatic_payment_methods: { enabled: true },
     });
-    res.json({ id: session.id });
+    res.send({ clientSecret: paymentIntent.client_secret });
   } catch (err) {
     res.status(500).json({ error: err.message });
   }


### PR DESCRIPTION
## Summary
- integrate Stripe Payment Intent API and expose publishable key securely
- add client-side card element and embedded pay button
- add env config example for Stripe keys

## Testing
- `npm test`
- `npm install dotenv@^16.3.1` *(fails: 403 Forbidden - GET https://registry.npmjs.org/dotenv)*

------
https://chatgpt.com/codex/tasks/task_e_68aba6bfa7f4832f93c3df027e9f5056